### PR TITLE
Add flake support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build Nix targets
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v5
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v3
+      - name: Build default package
+        run: nix build

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700612854,
+        "narHash": "sha256-yrQ8osMD+vDLGFX7pcwsY/Qr5PUd6OmDMYJZzZi0+zc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "19cbff58383a4ae384dea4d1d0c823d72b49d614",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "A gnss observations and products downloader";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachSystem
+      (with flake-utils.lib.system; [ x86_64-linux aarch64-linux ])
+      (system:
+        let
+          version = pkgs.lib.substring 0 8 self.lastModifiedDate or self.lastModified or "19700101";
+          meta = with pkgs.lib; {
+            license = licenses.mit;
+            maintainers = with maintainers; [ ocfox ];
+          };
+          pkgs = import nixpkgs { inherit system; };
+
+          gampii-good = pkgs.stdenv.mkDerivation {
+            pname = "gampii-good";
+            meta = meta;
+            version = version;
+
+            src = ./.;
+
+            buildInputs = with pkgs; [
+              cmake
+              yaml-cpp
+            ];
+
+          };
+
+        in
+        rec {
+          packages = {
+            gampii-good = gampii-good;
+            default = gampii-good;
+          };
+
+          devShells = rec {
+            default = gampii-dev;
+            gampii-dev = pkgs.mkShell {
+              inputsFrom = with packages; [ cmake make ];
+            };
+          };
+
+          apps = {
+            default = gampii-good;
+            gampii-good = {
+              type = "gampii-good";
+              program = "${self.packages.${system}.gampii-good}/bin/run_GOOD";
+            };
+          };
+        }
+      );
+}


### PR DESCRIPTION
Adding flake support will greatly simplify the build and environment requirements.

Github CI will not pass before #1 is merged.